### PR TITLE
Fix async Bukkit usage and placeholder prefix

### DIFF
--- a/src/main/java/au/com/addstar/swaparoo/PlaceholderAPI.java
+++ b/src/main/java/au/com/addstar/swaparoo/PlaceholderAPI.java
@@ -13,7 +13,11 @@ public class PlaceholderAPI extends PlaceholderExpansion {
 
     @Override
     public @NotNull String getIdentifier() {
-        return "Swaparoo";
+        // Placeholder identifiers in PlaceholderAPI are case-sensitive and
+        // conventionally lowercase. The placeholders documented in the README
+        // use the lowercase prefix "swaparoo", so return that value to ensure
+        // the expansion is correctly recognised by PlaceholderAPI.
+        return "swaparoo";
     }
 
     @Override

--- a/src/main/java/au/com/addstar/swaparoo/StarManager.java
+++ b/src/main/java/au/com/addstar/swaparoo/StarManager.java
@@ -32,21 +32,28 @@ public class StarManager {
     }
 
     public boolean setStars(UUID playerid, String type, int amount, boolean notifyPlayer) {
-        Player player = plugin.getServer().getPlayer(playerid);
-        String name = player != null ? player.getName() : "unknown";
         if (dataManager.setStarCount(playerid, type, amount)) {
-            SwaparooPlugin.debugMsg("Player " + name + " (" + playerid + ") now has " + amount + " " + type);
+            if (notifyPlayer || SwaparooPlugin.isDebug()) {
+                int finalAmount = amount;
+                plugin.getServer().getScheduler().runTask(plugin, () -> {
+                    Player player = plugin.getServer().getPlayer(playerid);
+                    String name = player != null ? player.getName() : "unknown";
+                    SwaparooPlugin.debugMsg("Player " + name + " (" + playerid + ") now has " + finalAmount + " " + type);
 
-            if (notifyPlayer) {
-                Integer starCount = dataManager.getStarCount(playerid, type, false);
-                String typeFormatted = type.contains("gems") ? "<yellow>Star<gold>Gems</gold></yellow>" : "<yellow>Star<white>Dust</white></yellow>";
-                if (player != null) {
-                    plugin.sendMsg(player, "<light_purple>►► <green>You now have <aqua>" + starCount + " " + typeFormatted);
-                }
+                    if (notifyPlayer && player != null) {
+                        String typeFormatted = type.contains("gems") ? "<yellow>Star<gold>Gems</gold></yellow>" : "<yellow>Star<white>Dust</white></yellow>";
+                        plugin.sendMsg(player, "<light_purple>►► <green>You now have <aqua>" + finalAmount + " " + typeFormatted);
+                    }
+                });
             }
             return true;
         } else {
-            SwaparooPlugin.errMsg("Failed to set " + type + " for player " + name + " (" + playerid + ") to " + amount);
+            int finalAmount = amount;
+            plugin.getServer().getScheduler().runTask(plugin, () -> {
+                Player player = plugin.getServer().getPlayer(playerid);
+                String name = player != null ? player.getName() : "unknown";
+                SwaparooPlugin.errMsg("Failed to set " + type + " for player " + name + " (" + playerid + ") to " + finalAmount);
+            });
             return false;
         }
     }

--- a/src/main/java/au/com/addstar/swaparoo/SwaparooPlugin.java
+++ b/src/main/java/au/com/addstar/swaparoo/SwaparooPlugin.java
@@ -111,7 +111,8 @@ public final class SwaparooPlugin extends JavaPlugin implements Listener {
 
     public static void debugMsg(String msg) {
         if (config.getDebug())
-            instance.getLogger().info("[Swaproo] DEBUG: " + msg);
+            // Correct plugin name in debug messages
+            instance.getLogger().info("[Swaparoo] DEBUG: " + msg);
     }
 
     public static boolean isDebug() {


### PR DESCRIPTION
## Summary
- lowercase the PlaceholderAPI identifier so placeholders work
- fix plugin name typo in debug messages
- avoid using Bukkit APIs off the main thread in star operations
- restore player name and UUID in error logs for failed star updates

## Testing
- `./gradlew assemble --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684264d69204832c880422582d165a12