### PR TITLE
Fix statement leak and cache cleanup

### DIFF
--- a/src/main/java/au/com/addstar/swaparoo/DatabaseManager.java
+++ b/src/main/java/au/com/addstar/swaparoo/DatabaseManager.java
@@ -104,6 +104,8 @@ public abstract class DatabaseManager {
     public ResultSet executeQuery(Connection conn, String query, Object... params) throws SQLException {
         //SwaparooPlugin.debugMsg(className + ": executeQuery: " + query);
         PreparedStatement statement = prepareStatement(conn, query, params);
+        // Automatically close the statement when the result set is closed to avoid leaks
+        statement.closeOnCompletion();
         return statement.executeQuery();
     }
 

--- a/src/main/java/au/com/addstar/swaparoo/PlayerKVCacheManager.java
+++ b/src/main/java/au/com/addstar/swaparoo/PlayerKVCacheManager.java
@@ -41,8 +41,12 @@ public class PlayerKVCacheManager {
     public Map<String, Integer> getPlayerCounts(UUID playerId) {
         // Check the cache
         CacheEntry entry = cache.get(playerId);
-        if (entry != null && !entry.isExpired()) {
-            return entry.getMapCounts();
+        if (entry != null) {
+            if (!entry.isExpired()) {
+                return entry.getMapCounts();
+            }
+            // Remove expired entries to prevent memory leaks
+            cache.remove(playerId);
         }
         return null;
     }


### PR DESCRIPTION
## Summary
- cleanup expired entries from the player cache
- close PreparedStatement when ResultSet is closed

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68621a170e48832cbfe39f019c2a8cd3